### PR TITLE
feature: -aオプション

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,10 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'optparse'
+
 MAX_COLUMNS = 3
 
 def main
-  dir_and_files = Dir.glob('*').sort
+  options = ARGV.getopts('a')
+  dir_and_files = (options['a'] ? Dir.entries('.') : Dir.glob('*')).sort
 
   puts format_columns(dir_and_files)
 end


### PR DESCRIPTION
## やったこと

* -aオプションですべてのファイルを表示できるようにした

## 確認してほしいこと

```sh
cd 04.ls
mkdir 1 2 3 4 5 6 7 日本語 あいうえお 1000 100こんにちは
./ls.rb
./ls.rb -a
```

これで `-a` オプションをつけた際に `.` `..` `.gitkeep` が表示されることを確認